### PR TITLE
Fix time machine behavior in dialogs by always using AlertContainerScreen to render AppWorkflow.

### DIFF
--- a/app/src/main/java/com/example/gameworkflow/AppWorkflow.kt
+++ b/app/src/main/java/com/example/gameworkflow/AppWorkflow.kt
@@ -11,7 +11,7 @@ import com.squareup.workflow.ui.AlertScreen.Button.POSITIVE
 class AppWorkflow internal constructor(
     gameLoaderService: GameLoader,
     private val gameWorkflow: GameWorkflow
-) : StatefulWorkflow<Unit, State, Nothing, Any>() {
+) : StatefulWorkflow<Unit, State, Nothing, AlertContainerScreen<Any>>() {
 
     private val gameLoader = gameLoaderService.loadGame().asWorker()
 
@@ -25,14 +25,19 @@ class AppWorkflow internal constructor(
         return LoadingGame
     }
 
-    override fun render(props: Unit, state: State, context: RenderContext<State, Nothing>): Any {
+    override fun render(
+        props: Unit,
+        state: State,
+        context: RenderContext<State, Nothing>
+    ): AlertContainerScreen<Any> {
         when (state) {
             LoadingGame -> {
                 context.runningWorker(gameLoader) { startGame(it) }
-                return LoadingScreen
+                return AlertContainerScreen(LoadingScreen)
             }
             is PlayingGame -> {
-                return context.renderChild(gameWorkflow, state.game) { finishGame }
+                val bodyScreen = context.renderChild(gameWorkflow, state.game) { finishGame }
+                return AlertContainerScreen(bodyScreen)
             }
             is GameOver -> {
                 val gameRendering = context.renderChild(gameWorkflow, state.game) {


### PR DESCRIPTION
Crashes at the end because we're still not blocking events from the dialog screen.

Related to https://github.com/square/workflow/issues/568, but doesn't fix it because the dialog should still be dismissed even if the workflow is doing the "wrong" thing.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/101754/65925451-cffbb780-e3a5-11e9-815e-fe416cc9024e.gif)
